### PR TITLE
Remove margin:inherit

### DIFF
--- a/d2l-status-indicator.html
+++ b/d2l-status-indicator.html
@@ -15,7 +15,6 @@ Polymer-based web component for a D2L status indicator
 			}
 
 			.d2l-status-indicator {
-				margin: inherit;
 				border-width: 1px;
 				border-style: solid;
 				border-radius: 12px;


### PR DESCRIPTION
Including `margin: inherit` means that all margins applied to the component via its container are doubled. This means that they need to be halved in order to achieve desired effects, which feels sort of like a π vs τ situation.