### PR TITLE
Fixing line-height / padding

### DIFF
--- a/d2l-status-indicator.html
+++ b/d2l-status-indicator.html
@@ -15,16 +15,17 @@ Polymer-based web component for a D2L status indicator
 			}
 
 			.d2l-status-indicator {
-				border-width: 1px;
+				border-radius: 0.6rem;
 				border-style: solid;
-				border-radius: 12px;
-				padding: 2px 10px 2px 10px;
+				border-width: 1px;
+				cursor: default;
 				font-size: 0.6rem;
-				line-height: 0.7rem;
-				text-transform: uppercase;
 				font-weight: bold;
-				text-overflow: ellipsis;
+				line-height: 1;
 				overflow: hidden;
+				padding: 2px 10px 2px 10px;
+				text-transform: uppercase;
+				text-overflow: ellipsis;
 				white-space: nowrap;
 			}
 
@@ -42,7 +43,7 @@ Polymer-based web component for a D2L status indicator
 			}
 			:host([state="alert"]) .d2l-status-indicator {
 				border-color: var(--d2l-color-cinnabar);
-				color: var(--d2l-color-cinnabar);;
+				color: var(--d2l-color-cinnabar);
 			}
 			:host([state="none"]) .d2l-status-indicator,
 			:host([state="null"]) .d2l-status-indicator {


### PR DESCRIPTION
Since status indicators contain text, the height/padding of the rendered element is a delicate balance between its line height and padding.

Here's the spec from the design (note: the `10px` and `5px` values _include_ the borders):
![screen shot 2018-06-18 at 12 44 50 pm](https://user-images.githubusercontent.com/5491151/41549966-6a5db24c-72f5-11e8-90a0-1f3d07e995f2.png)

By using a line height of `1`, combined with top/bottom padding of `2px`, the end result is `4px` above and either `4px` or `5px` below the text, depending on the font size and the browser. When combined with the `1px` border, this achieves the design.

I'm going to follow this up with some breaking changes that apply a `vertical-align: middle` so that the text will automatically vertically align with other text elements on the same line, as well as making it `inline-block` by default.