### PR TITLE
Refactor & inline-block

### DIFF
--- a/d2l-status-indicator.html
+++ b/d2l-status-indicator.html
@@ -10,15 +10,13 @@ Polymer-based web component for a D2L status indicator
 	<template strip-whitespace>
 		<style>
 			:host {
-				display: flex;
-				flex-direction: row;
-			}
-
-			.d2l-status-indicator {
+				border-color: var(--d2l-color-celestine);
 				border-radius: 0.6rem;
 				border-style: solid;
 				border-width: 1px;
+				color: var(--d2l-color-celestine);
 				cursor: default;
+				display: inline-block;
 				font-size: 0.6rem;
 				font-weight: bold;
 				line-height: 1;
@@ -26,35 +24,28 @@ Polymer-based web component for a D2L status indicator
 				padding: 2px 10px 2px 10px;
 				text-transform: uppercase;
 				text-overflow: ellipsis;
+				vertical-align: middle;
 				white-space: nowrap;
 			}
 
 			:host([hidden]) {
 				display: none;
 			}
-
-			.d2l-status-indicator {
-				border-color: var(--d2l-color-celestine);
-				color: var(--d2l-color-celestine);
-			}
-			:host([state="success"]) .d2l-status-indicator {
+			:host([state="success"]) {
 				border-color: var(--d2l-color-olivine-minus-1);
 				color: var(--d2l-color-olivine-minus-1);
 			}
-			:host([state="alert"]) .d2l-status-indicator {
+			:host([state="alert"]) {
 				border-color: var(--d2l-color-cinnabar);
 				color: var(--d2l-color-cinnabar);
 			}
-			:host([state="none"]) .d2l-status-indicator,
-			:host([state="null"]) .d2l-status-indicator {
+			:host([state="none"]),
+			:host([state="null"]) {
 				border-color: var(--d2l-color-ferrite);
 				color: var(--d2l-color-ferrite);
 			}
 		</style>
-
-		<div class="d2l-status-indicator">
-			[[text]]
-		</div>
+		[[text]]
 	</template>
 	<script>
 		Polymer({

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,6 +7,7 @@
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-colors/d2l-colors.html">
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
 		<link rel="import" href="../d2l-status-indicator.html">
 		<custom-style>
@@ -19,7 +20,17 @@
 			html {
 				font-size: 20px;
 			}
-			</style>
+			.align-item {
+				color: var(--d2l-color-tungsten);
+				font-size: 0.7rem;
+			}
+			.align-item.bullet::before {
+				color: var(--d2l-color-tungsten);
+				content: '\002022';
+				margin-left: 5px;
+				margin-right: 5px;
+			}
+		</style>
 	</head>
 	<body unresolved class="d2l-typography">
 		<div class="vertical-section-container centered">
@@ -49,6 +60,15 @@
 			<demo-snippet>
 				<template>
 					<d2l-status-indicator state="none" text="closed"></d2l-status-indicator>
+				</template>
+			</demo-snippet>
+
+			<h3>Alignment with other elements</h3>
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-status-indicator state="alert" text="overdue"></d2l-status-indicator>
+					<span class="align-item" style="margin-left:10px;">Grade 6 Science</span>
+					<span class="align-item bullet">Assignment</span>
 				</template>
 			</demo-snippet>
 		</div>


### PR DESCRIPTION
This will require a major version bump.

Changes:
- Refactored everything into a single DOM node
- Element is now `inline-block` instead of `block`, which means it can be positioned beside other elements inline easily without requiring floating or `flex-box`
- It's vertically aligned with other text elements (see below)

![screen shot 2018-06-18 at 2 34 52 pm](https://user-images.githubusercontent.com/5491151/41555435-af8b1b24-7305-11e8-8dd4-a2bbb634f3f6.png)
